### PR TITLE
Add encoding option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
 'use strict';
 
-module.exports = function (stream) {
+module.exports = function (stream, opts) {
 	if (!stream) {
 		return Promise.reject(new Error('Expected a stream'));
 	}
 
+	opts = opts || {};
+
 	var ret = '';
 
 	return new Promise(function (resolve, reject) {
-		stream.setEncoding('utf8');
+		stream.setEncoding(opts.encoding || 'utf8');
 
 		stream.on('readable', function () {
 			var chunk;

--- a/readme.md
+++ b/readme.md
@@ -48,9 +48,18 @@ getStream(stream).then(str => {
 
 Both methods returns a promise that is resolved when the `end` event fires on the stream, indicating that there is no more data to be read.
 
-### getStream(stream)
+### getStream(stream, [options])
 
 Get the stream as a string.
+
+#### options
+
+##### encoding
+
+Type: `string`
+Default: `utf8`
+
+Encoding of incoming stream, could be on of listed in [Buffer documentation](https://nodejs.org/api/buffer.html#buffer_buffer).
 
 ### getStream.buffer(stream)
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ import fn from './';
 
 test('get stream as a string', async t => {
 	t.is(await fn(fs.createReadStream('fixture')), 'unicorn\n');
+	t.is(await fn(fs.createReadStream('fixture'), {encoding: 'hex'}), '756e69636f726e0a');
 });
 
 test('get stream as a buffer', async t => {


### PR DESCRIPTION
I'm planning to switch from `read-all-stream` to `get-stream` in next release of `got`, so `encoding` option would be nice to have :sparkles: 