### PR TITLE
Avoid calling setEncoding on the provided stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ function getStream(inputStream, opts) {
 		return Promise.reject(new Error('Expected a stream'));
 	}
 
-	opts = opts || {};
 	var stream;
-	var encoding = opts.encoding || 'utf8';
+	var encoding = (opts && opts.encoding) || 'utf8';
 	var buffer = encoding === 'buffer';
+	var array = encoding === 'array';
 
-	if (buffer || encoding === 'array') {
+	if (buffer || array) {
 		encoding = null;
 	}
 
@@ -32,7 +32,7 @@ function getStream(inputStream, opts) {
 	}
 
 	var p = new Promise(function (resolve, reject) {
-		stream = new PassThrough({objectMode: !encoding && !buffer});
+		stream = new PassThrough({objectMode: array});
 		inputStream.pipe(stream);
 
 		if (encoding) {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 'use strict';
+var PassThrough = require('stream').PassThrough;
 var Promise = require('pinkie-promise');
 
-function getStream(stream, opts) {
-	if (!stream) {
+function getStream(inputStream, opts) {
+	if (!inputStream) {
 		return Promise.reject(new Error('Expected a stream'));
 	}
 
 	opts = opts || {};
+	var stream;
 	var encoding = opts.encoding || 'utf8';
 	var buffer = encoding === 'buffer';
 
@@ -30,6 +32,9 @@ function getStream(stream, opts) {
 	}
 
 	var p = new Promise(function (resolve, reject) {
+		stream = new PassThrough({objectMode: !encoding && !buffer});
+		inputStream.pipe(stream);
+
 		if (encoding) {
 			stream.setEncoding(encoding);
 		}

--- a/test.js
+++ b/test.js
@@ -26,3 +26,12 @@ test('get object stream as an array', async t => {
 	const fixture = [{foo: true}, {bar: false}];
 	t.deepEqual(await m.array(intoStream.obj(fixture)), fixture);
 });
+
+test('getStream should not affect additional listeners attached to the stream', async t => {
+	t.plan(3);
+	const fixture = intoStream(['foo', 'bar']);
+
+	fixture.on('data', chunk => t.true(Buffer.isBuffer(chunk)));
+
+	t.is(await m(fixture), 'foobar');
+});


### PR DESCRIPTION
Calling setEncoding on the provided stream affects the data other listeners will see.

This side effect can be avoided by first piping to a PassThrough stream.