### PR TITLE
Implement maxBuffer checks. Fixes #8.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function getStream(inputStream, opts) {
 			}
 
 			if (len > maxBuffer) {
-				reject(new Error('maxBuffer'));
+				reject(new Error('maxBuffer exceeded'));
 			}
 		};
 

--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
 'use strict';
 var PassThrough = require('stream').PassThrough;
 var Promise = require('pinkie-promise');
+var objectAssign = require('object-assign');
 
 function getStream(inputStream, opts) {
 	if (!inputStream) {
 		return Promise.reject(new Error('Expected a stream'));
 	}
 
-	var stream;
-	var array = opts && opts.array;
-	var encoding = opts && opts.encoding;
-	var maxBuffer = opts && opts.maxBuffer;
+	opts = objectAssign({maxBuffer: Infinity}, opts);
 
-	if (typeof maxBuffer !== 'number') {
-		maxBuffer = Infinity;
-	}
+	var stream;
+	var array = opts.array;
+	var encoding = opts.encoding;
+	var maxBuffer = opts.maxBuffer;
 
 	var buffer = encoding === 'buffer';
 	var objectMode = false;
@@ -77,16 +76,9 @@ function getStream(inputStream, opts) {
 module.exports = getStream;
 
 module.exports.buffer = function (stream, opts) {
-	return getStream(stream, {
-		encoding: 'buffer',
-		maxBuffer: opts && opts.maxBuffer
-	});
+	return getStream(stream, objectAssign({}, opts, {encoding: 'buffer'}));
 };
 
 module.exports.array = function (stream, opts) {
-	return getStream(stream, {
-		array: true,
-		encoding: opts && opts.encoding,
-		maxBuffer: opts && opts.maxBuffer
-	});
+	return getStream(stream, objectAssign({}, opts, {array: true}));
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "obj"
   ],
   "dependencies": {
+    "object-assign": "^4.0.1",
     "pinkie-promise": "^2.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -61,15 +61,30 @@ Default: `utf8`
 
 [Encoding](https://nodejs.org/api/buffer.html#buffer_buffer) of the incoming stream.
 
-### getStream.buffer(stream)
+##### maxBuffer
+
+Type: `number`<br>
+Default: `Infinity`
+
+Maximum length of the returned string. If it exceeds this value before the stream ends, the promise will be rejected.
+
+### getStream.buffer(stream, [options])
 
 Get the `stream` as a buffer.
 
-### getStream.array(stream)
+It honors the `maxBuffer` option as above, but it refers to byte length rather than string length.
+
+### getStream.array(stream, [options])
 
 Get the `stream` as an array of values.
 
-Especially useful for [object mode streams](https://nodesource.com/blog/understanding-object-streams/).
+It honors both the `maxBuffer` and `encoding` options. The behavior changes slightly based on the encoding chosen:
+
+- When `encoding` is unset, it assumes an [object mode stream](https://nodesource.com/blog/understanding-object-streams/) and collects values emitted from `stream` unmodified. In this case `maxBuffer` refers to the number of items in the array (not the sum of their sizes).
+
+- When `encoding` is set to `buffer`, it collects an array of buffers. `maxBuffer` refers to the summed byte lengths of every buffer in the array.
+
+- When `encoding` is set to anything else, it collects an array of strings. `maxBuffer` refers to the summed character lengths of every string in the array.
 
 
 ## FAQ

--- a/test.js
+++ b/test.js
@@ -27,6 +27,22 @@ test('get object stream as an array', async t => {
 	t.deepEqual(await m.array(intoStream.obj(fixture)), fixture);
 });
 
+test('get non-object stream as an array of strings', async t => {
+	const stream = intoStream(['foo', 'bar']);
+
+	const result = await m.array(stream, {encoding: 'utf8'});
+
+	t.deepEqual(result, ['foo', 'bar']);
+});
+
+test('get non-object stream as an array of Buffers', async t => {
+	const stream = intoStream(['foo', 'bar']);
+
+	const result = await m.array(stream, {encoding: 'buffer'});
+
+	t.deepEqual(result, [new Buffer('foo'), new Buffer('bar')]);
+});
+
 test('getStream should not affect additional listeners attached to the stream', async t => {
 	t.plan(3);
 	const fixture = intoStream(['foo', 'bar']);

--- a/test.js
+++ b/test.js
@@ -71,13 +71,13 @@ test('maxBuffer throws when size is exceeded', t => {
 });
 
 test('maxBuffer applies to length of arrays when in objectMode', t => {
-	t.throws(m.array(intoStream.obj([{a: 1}, {b: 2}, {c: 3}, {d: 4}]), {maxBuffer: 3}));
+	t.throws(m.array(intoStream.obj([{a: 1}, {b: 2}, {c: 3}, {d: 4}]), {maxBuffer: 3}), /maxBuffer exceeded/);
 	t.notThrows(m.array(intoStream.obj([{a: 1}, {b: 2}, {c: 3}]), {maxBuffer: 3}));
 });
 
 test('maxBuffer applies to length of data when not in objectMode', t => {
-	t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 5}));
+	t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 5}), /maxBuffer exceeded/);
 	t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 6}));
-	t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 5}));
+	t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 5}), /maxBuffer exceeded/);
 	t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 6}));
 });


### PR DESCRIPTION
All methods now take an options object, and all honor the `maxBuffer` option.

If `maxBuffer` is set to a number, the promise will reject once the specified limit is reached.

Changes the behavior of the `array` method slightly, as it now honors an `encoding` option:

 - If `encoding` is unset, it defaults to ObjectMode, and `maxBuffer` applies to the number of objects pushed to the array.
 - If `encoding` is set to `buffer`, it will push Buffers to the array, throwing when the total length of all received Buffers exceeds maxBuffer.
 - If `encoding` is set to anything else, it will decode each chunk to a String, and push it to the array, throwing when the total length of all received Strings exceeds maxBuffer.