### PR TITLE
Reject promise when input stream emits an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function getStream(inputStream, opts) {
 
 	var p = new Promise(function (resolve, reject) {
 		stream = bufferStream(opts);
+		inputStream.on('error', reject);
 		inputStream.pipe(stream);
 
 		stream.on('data', function () {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,12 @@ function getStream(inputStream, opts) {
 
 	var p = new Promise(function (resolve, reject) {
 		stream = bufferStream(opts);
-		inputStream.on('error', reject);
+		inputStream.on('error', err => {
+			if (err) { // null check
+				err.buffer = stream.getBufferedValue();
+			}
+			reject(err);
+		});
 		inputStream.pipe(stream);
 
 		stream.on('data', function () {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function getStream(inputStream, opts) {
 
 	var p = new Promise(function (resolve, reject) {
 		stream = bufferStream(opts);
-		inputStream.on('error', error);
+		inputStream.once('error', error);
 		inputStream.pipe(stream);
 
 		stream.on('data', function () {
@@ -23,7 +23,7 @@ function getStream(inputStream, opts) {
 				reject(new Error('maxBuffer exceeded'));
 			}
 		});
-		stream.on('error', error);
+		stream.once('error', error);
 		stream.on('end', resolve);
 
 		clean = function () {

--- a/index.js
+++ b/index.js
@@ -15,12 +15,7 @@ function getStream(inputStream, opts) {
 
 	var p = new Promise(function (resolve, reject) {
 		stream = bufferStream(opts);
-		inputStream.on('error', err => {
-			if (err) { // null check
-				err.buffer = stream.getBufferedValue();
-			}
-			reject(err);
-		});
+		inputStream.on('error', error);
 		inputStream.pipe(stream);
 
 		stream.on('data', function () {
@@ -28,12 +23,19 @@ function getStream(inputStream, opts) {
 				reject(new Error('maxBuffer exceeded'));
 			}
 		});
-		stream.on('error', reject);
+		stream.on('error', error);
 		stream.on('end', resolve);
 
 		clean = function () {
 			inputStream.unpipe(stream);
 		};
+
+		function error(err) {
+			if (err) { // null check
+				err.buffer = stream.getBufferedValue();
+			}
+			reject(err);
+		}
 	});
 
 	p.then(clean, clean);

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,17 @@ It honors both the `maxBuffer` and `encoding` options. The behavior changes slig
 - When `encoding` is set to anything else, it collects an array of strings. `maxBuffer` refers to the summed character lengths of every string in the array.
 
 
+## Errors
+
+When input stream emits an error, promise is rejected. The data gathered up until the error is passed via `buffer` property on the error object.
+
+```js
+getStream(streamThatErrorsAtTheEnd('unicorn'))
+	.catch(err => console.log(err.buffer));
+// unicorn
+```
+
+
 ## FAQ
 
 ### How is this different from [`concat-stream`](https://github.com/maxogden/concat-stream)?

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ It honors both the `maxBuffer` and `encoding` options. The behavior changes slig
 
 ## Errors
 
-When input stream emits an error, promise is rejected. The data gathered up until the error is passed via `buffer` property on the error object.
+If the input stream emits an `error` event, the promise will be rejected with the error. The buffered contents will be attached to the `buffer` property of the error.
 
 ```js
 getStream(streamThatErrorsAtTheEnd('unicorn'))

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import {Readable} from 'stream';
 import test from 'ava';
 import bufferEquals from 'buffer-equals';
 import intoStream from 'into-stream';
@@ -80,4 +81,12 @@ test('maxBuffer applies to length of data when not in objectMode', t => {
 	t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 6}));
 	t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 5}), /maxBuffer exceeded/);
 	t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 6}));
+});
+
+test('Promise rejects when input stream emits an error', t => {
+	const readable = new Readable();
+	readable._read = function () {
+		this.emit('error', new Error('Made up error.'));
+	};
+	t.throws(m(readable));
 });


### PR DESCRIPTION
Input stream errors are not caught so they hang the promise, which never resolves or rejects. Got bitten by this right now.