### PR TITLE
Check if `unpipe` exists on `inputStream` before calling it

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function getStream(inputStream, opts) {
 		stream.on('end', resolve);
 
 		clean = function () {
+			// some streams doesn't implement the stream.Readable interface correctly
 			if (inputStream.unpipe) {
 				inputStream.unpipe(stream);
 			}

--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ function getStream(inputStream, opts) {
 		stream.on('end', resolve);
 
 		clean = function () {
-			inputStream.unpipe(stream);
+			if (inputStream.unpipe) {
+				inputStream.unpipe(stream);
+			}
 		};
 
 		function error(err) {


### PR DESCRIPTION
Some streams doesn't implement the `Readable` interface correctly and therefore doesn't have the `unpipe` method attached to them.

Fixes #17.