### PR TITLE
Use `pump` module for better stream handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - '10'
+  - '9'
+  - '8'
   - '6'
-  - '4'

--- a/buffer-stream.js
+++ b/buffer-stream.js
@@ -1,11 +1,11 @@
 'use strict';
-const PassThrough = require('stream').PassThrough;
+const {PassThrough} = require('stream');
 
 module.exports = opts => {
 	opts = Object.assign({}, opts);
 
-	const array = opts.array;
-	let encoding = opts.encoding;
+	const {array} = opts;
+	let {encoding} = opts;
 	const buffer = encoding === 'buffer';
 	let objectMode = false;
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function getStream(inputStream, opts) {
 		);
 		stream.on('data', () => {
 			if (stream.getBufferedLength() > maxBuffer) {
-				stream.destroy(new Error('maxBuffer exceeded'));
+				error(new Error('maxBuffer exceeded'));
 			}
 		});
 	}).then(() => stream.getBufferedValue());

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const pump = require('pump');
 const bufferStream = require('./buffer-stream');
 
 function getStream(inputStream, opts) {
@@ -8,42 +9,26 @@ function getStream(inputStream, opts) {
 
 	opts = Object.assign({maxBuffer: Infinity}, opts);
 
-	const maxBuffer = opts.maxBuffer;
+	const {maxBuffer} = opts;
 	let stream;
-	let clean;
 
-	const p = new Promise((resolve, reject) => {
+	return new Promise((resolve, reject) => {
 		const error = err => {
-			if (err) { // null check
+			if (err) { // A null check
 				err.bufferedData = stream.getBufferedValue();
 			}
-
 			reject(err);
 		};
 
-		stream = bufferStream(opts);
-		inputStream.once('error', error);
-		inputStream.pipe(stream);
-
+		stream = pump(inputStream, bufferStream(opts), err =>
+			err ? error(err) : resolve()
+		);
 		stream.on('data', () => {
 			if (stream.getBufferedLength() > maxBuffer) {
-				reject(new Error('maxBuffer exceeded'));
+				stream.destroy(new Error('maxBuffer exceeded'));
 			}
 		});
-		stream.once('error', error);
-		stream.on('end', resolve);
-
-		clean = () => {
-			// some streams doesn't implement the `stream.Readable` interface correctly
-			if (inputStream.unpipe) {
-				inputStream.unpipe(stream);
-			}
-		};
-	});
-
-	p.then(clean, clean);
-
-	return p.then(() => stream.getBufferedValue());
+	}).then(() => stream.getBufferedValue());
 }
 
 module.exports = getStream;

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
   },
   "xo": {
     "esnext": true
+  },
+  "dependencies": {
+    "pump": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && ava"

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import {Readable} from 'stream';
 import test from 'ava';
 import intoStream from 'into-stream';
-import m from './';
+import m from '.';
 
 function makeSetup(intoStream) {
 	const setup = (streamDef, opts) => m(intoStream(streamDef), opts);
@@ -15,7 +15,7 @@ const setup = makeSetup(intoStream);
 setup.obj = makeSetup(intoStream.obj);
 
 test('get stream as a buffer', async t => {
-	t.true((await m.buffer(fs.createReadStream('fixture'))).equals(new Buffer('unicorn\n')));
+	t.true((await m.buffer(fs.createReadStream('fixture'))).equals(Buffer.from('unicorn\n')));
 });
 
 test('get stream as an array', async t => {
@@ -36,7 +36,7 @@ test('get non-object stream as an array of strings', async t => {
 
 test('get non-object stream as an array of Buffers', async t => {
 	const result = await setup.array(['foo', 'bar'], {encoding: 'buffer'});
-	t.deepEqual(result, [new Buffer('foo'), new Buffer('bar')]);
+	t.deepEqual(result, [Buffer.from('foo'), Buffer.from('bar')]);
 });
 
 test('getStream should not affect additional listeners attached to the stream', async t => {
@@ -46,24 +46,24 @@ test('getStream should not affect additional listeners attached to the stream', 
 	t.is(await m(fixture), 'foobar');
 });
 
-test('maxBuffer throws when size is exceeded', t => {
-	t.throws(setup(['abcd'], {maxBuffer: 3}));
-	t.notThrows(setup(['abc'], {maxBuffer: 3}));
+test('maxBuffer throws when size is exceeded', async t => {
+	await t.throws(setup(['abcd'], {maxBuffer: 3}));
+	await t.notThrows(setup(['abc'], {maxBuffer: 3}));
 
-	t.throws(setup.buffer(['abcd'], {maxBuffer: 3}));
-	t.notThrows(setup.buffer(['abc'], {maxBuffer: 3}));
+	await t.throws(setup.buffer(['abcd'], {maxBuffer: 3}));
+	await t.notThrows(setup.buffer(['abc'], {maxBuffer: 3}));
 });
 
-test('maxBuffer applies to length of arrays when in objectMode', t => {
-	t.throws(m.array(intoStream.obj([{a: 1}, {b: 2}, {c: 3}, {d: 4}]), {maxBuffer: 3}), /maxBuffer exceeded/);
-	t.notThrows(m.array(intoStream.obj([{a: 1}, {b: 2}, {c: 3}]), {maxBuffer: 3}));
+test('maxBuffer applies to length of arrays when in objectMode', async t => {
+	await t.throws(m.array(intoStream.obj([{a: 1}, {b: 2}, {c: 3}, {d: 4}]), {maxBuffer: 3}), /maxBuffer exceeded/);
+	await t.notThrows(m.array(intoStream.obj([{a: 1}, {b: 2}, {c: 3}]), {maxBuffer: 3}));
 });
 
-test('maxBuffer applies to length of data when not in objectMode', t => {
-	t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 5}), /maxBuffer exceeded/);
-	t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 6}));
-	t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 5}), /maxBuffer exceeded/);
-	t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 6}));
+test('maxBuffer applies to length of data when not in objectMode', async t => {
+	await t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 5}), /maxBuffer exceeded/);
+	await t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'utf8', maxBuffer: 6}));
+	await t.throws(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 5}), /maxBuffer exceeded/);
+	await t.notThrows(setup.array(['ab', 'cd', 'ef'], {encoding: 'buffer', maxBuffer: 6}));
 });
 
 test('Promise rejects when input stream emits an error', async t => {


### PR DESCRIPTION
- uses pump to fix edge cases with destroy not working
  - this will probably fix a lot of other edge cases as well with backpressure, error fwding, etc. that a plain `pipe` was not dealing with before
- fixes tests that were not ending correctly (Related: https://github.com/avajs/ava/issues/1327#issuecomment-291122803)
- fixes Buffer deprecations in tests
- fixes linter issues

Fixes #23