### PR TITLE
Use native `stream.pipeline` instead of `pump` package

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,14 @@ async function getStream(inputStream, options) {
 			reject(error);
 		};
 
-		streamPipelinePromisified(inputStream, stream).then(resolve, rejectPromise);
+		(async () => {
+			try {
+				await streamPipelinePromisified(inputStream, stream);
+				resolve();
+			} catch (error) {
+				rejectPromise(error);
+			}
+		})();
 
 		stream.on('data', () => {
 			if (stream.getBufferedLength() > maxBuffer) {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ class MaxBufferError extends Error {
 
 async function getStream(inputStream, options) {
 	if (!inputStream) {
-		return Promise.reject(new Error('Expected a stream'));
+		throw new Error('Expected a stream');
 	}
 
 	options = {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
 const {constants: BufferConstants} = require('buffer');
 const {pipeline} = require('stream');
+const {promisify} = require('util');
 const bufferStream = require('./buffer-stream');
+
+const streamPipelinePromisified = promisify(pipeline);
 
 class MaxBufferError extends Error {
 	constructor() {
@@ -33,14 +36,7 @@ async function getStream(inputStream, options) {
 			reject(error);
 		};
 
-		pipeline(inputStream, stream, error => {
-			if (error) {
-				rejectPromise(error);
-				return;
-			}
-
-			resolve();
-		});
+		streamPipelinePromisified(inputStream, stream).then(resolve, rejectPromise);
 
 		stream.on('data', () => {
 			if (stream.getBufferedLength() > maxBuffer) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const {constants: BufferConstants} = require('buffer');
-const pump = require('pump');
+const {pipeline} = require('stream');
 const bufferStream = require('./buffer-stream');
 
 class MaxBufferError extends Error {
@@ -22,7 +22,7 @@ async function getStream(inputStream, options) {
 
 	const {maxBuffer} = options;
 
-	let stream;
+	const stream = bufferStream(options);
 	await new Promise((resolve, reject) => {
 		const rejectPromise = error => {
 			// Don't retrieve an oversized buffer.
@@ -33,7 +33,7 @@ async function getStream(inputStream, options) {
 			reject(error);
 		};
 
-		stream = pump(inputStream, bufferStream(options), error => {
+		pipeline(inputStream, stream, error => {
 			if (error) {
 				rejectPromise(error);
 				return;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 const {constants: BufferConstants} = require('buffer');
-const {pipeline} = require('stream');
+const stream = require('stream');
 const {promisify} = require('util');
 const bufferStream = require('./buffer-stream');
 
-const streamPipelinePromisified = promisify(pipeline);
+const streamPipelinePromisified = promisify(stream.pipeline);
 
 class MaxBufferError extends Error {
 	constructor() {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 		"array",
 		"object"
 	],
-	"dependencies": {},
 	"devDependencies": {
 		"@types/node": "^12.0.7",
 		"ava": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
 		"array",
 		"object"
 	],
-	"dependencies": {
-		"pump": "^3.0.0"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@types/node": "^12.0.7",
 		"ava": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
This PR replaces the use of the pump package with the native `stream.pipeline`, introduced on node@10.0.0 (requested on https://github.com/sindresorhus/get-stream/issues/33). This fixes https://github.com/sindresorhus/get-stream/issues/38.
  
Also, a nit, it replaces `return Promise.reject(new Error...)` with `throw new Error...`

This is a breaking change