### PR TITLE
Allow `maxBuffer` option to be set to Buffer `MAX_LENGTH`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const BufferConstants = require('buffer').constants;
 const pump = require('pump');
 const bufferStream = require('./buffer-stream');
 
@@ -24,7 +25,8 @@ async function getStream(inputStream, options) {
 	let stream;
 	await new Promise((resolve, reject) => {
 		const rejectPromise = error => {
-			if (error) { // A null check
+			// A null check and make sure we're not going to try to retreive an oversized buffer
+			if (error && stream.getBufferedLength() <= BufferConstants.MAX_LENGTH) {
 				error.bufferedData = stream.getBufferedValue();
 			}
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const BufferConstants = require('buffer').constants;
+const {constants: BufferConstants} = require('buffer');
 const pump = require('pump');
 const bufferStream = require('./buffer-stream');
 
@@ -25,7 +25,7 @@ async function getStream(inputStream, options) {
 	let stream;
 	await new Promise((resolve, reject) => {
 		const rejectPromise = error => {
-			// A null check and make sure we're not going to try to retreive an oversized buffer
+			// Don't retrieve an oversized buffer.
 			if (error && stream.getBufferedLength() <= BufferConstants.MAX_LENGTH) {
 				error.bufferedData = stream.getBufferedValue();
 			}

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import {constants as BufferConstants} from 'buffer';
 import {Readable as ReadableStream} from 'stream';
 import test from 'ava';
 import intoStream from 'into-stream';
@@ -68,6 +69,16 @@ test('maxBuffer applies to length of data when not in objectMode', async t => {
 
 test('maxBuffer throws a MaxBufferError', async t => {
 	await t.throwsAsync(setup(['abcd'], {maxBuffer: 3}), getStream.MaxBufferError);
+});
+
+test('maxBuffer throws a MaxBufferError even if the stream is larger than Buffer MAX_LENGTH', async t => {
+	// Create a stream 1 byte larger than the maximum size a buffer is allowed to be
+	function * largeStream() {
+		yield Buffer.allocUnsafe(BufferConstants.MAX_LENGTH);
+		yield Buffer.allocUnsafe(1);
+	}
+
+	await t.throwsAsync(setup(largeStream(), {maxBuffer: BufferConstants.MAX_LENGTH, encoding: 'buffer'}), /maxBuffer exceeded/);
 });
 
 test('Promise rejects when input stream emits an error', async t => {


### PR DESCRIPTION
This change allows passing Buffer's `MAX_LENGTH` constant as the `maxBuffer` option (or values larger than `MAX_LENGTH`). Fixes a bug where other errors would be hidden by a `RangeError` (e.g. "RangeError: "size" argument must not be larger than 2147483647") when the error handling code tried to call `getBufferedValue` while buffering a stream larger than Buffer's `MAX_LENGTH`.