### PR TITLE
Fix TypeScript type for the `.buffer()` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare const getStream: {
 	*/
 	buffer(
 		stream: Stream,
-		options?: getStream.OptionsWithEncoding
+		options?: getStream.Options
 	): Promise<Buffer>;
 
 	/**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,7 +11,6 @@ expectType<Promise<string>>(getStream(stream, {encoding: 'utf8'}));
 
 expectType<Promise<Buffer>>(getStream.buffer(stream));
 expectType<Promise<Buffer>>(getStream.buffer(stream, {maxBuffer: 10}));
-expectType<Promise<Buffer>>(getStream.buffer(stream, {encoding: 'utf8'}));
 
 expectType<Promise<unknown[]>>(getStream.array(stream));
 expectType<Promise<{}[]>>(getStream.array<{}>(stream));


### PR DESCRIPTION
From https://github.com/sindresorhus/get-stream/blob/831366e0b172411812e9ce797e4fbd83d28c8aeb/index.js#L59 `encoding` is always set to `buffer`