### PR TITLE
Document `node:stream/consumers`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ You may not need this package if you do not use any [options](#options).
 
 ```js
 import fs from 'node:fs';
-import {text,buffer} from 'node:stream/consumers';
+import {text, buffer} from 'node:stream/consumers';
 
 const stream = fs.createReadStream('unicorn.txt', {encoding: 'utf8'});
 

--- a/readme.md
+++ b/readme.md
@@ -97,15 +97,21 @@ try {
 
 ## Tip
 
-You may not need this package if all you need is a string:
+You may not need this package if you do not use any [options](#options).
 
 ```js
 import fs from 'node:fs';
+import {text,buffer} from 'node:stream/consumers';
 
 const stream = fs.createReadStream('unicorn.txt', {encoding: 'utf8'});
-const array = await stream.toArray();
 
-console.log(array.join(''));
+console.log(await text(stream))
+```
+
+or:
+
+```js
+console.log(await buffer(stream))
 ```
 
 ## FAQ

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import {Buffer} from 'node:buffer';
+import {text, buffer} from 'node:stream/consumers';
 import test from 'ava';
 import intoStream from 'into-stream';
 import getStream, {getStreamAsBuffer, MaxBufferError} from './index.js';
@@ -37,8 +38,12 @@ test('maxBuffer throws when size is exceeded', async t => {
 	await t.notThrowsAsync(setup.buffer(['abc'], {maxBuffer: 3}));
 });
 
-test('native', async t => {
-	const array = await fs.createReadStream('fixture', {encoding: 'utf8'}).toArray();
-	const result = array.join('');
+test('native string', async t => {
+	const result = await text(fs.createReadStream('fixture', {encoding: 'utf8'}));
 	t.is(result, 'unicorn\n');
+});
+
+test('native buffer', async t => {
+	const result = await buffer(fs.createReadStream('fixture', {encoding: 'utf8'}));
+	t.true(result.equals(Buffer.from('unicorn\n')));
 });


### PR DESCRIPTION
The methods exposed by `node:stream/consumers` (available since `16.14.0`): 
  - Are slightly simpler than calling `toArray()` + `join()`
  - Are faster
  - Work with browser-compatible `ReadableStream`, not only Node.js streams
  
They can also output buffers. For this reason, this PR also updates what seems to be the remaining reasons to use this package: the `maxBuffer` and `encoding` options.