### PR TITLE
Improve performance

### DIFF
--- a/test.js
+++ b/test.js
@@ -19,13 +19,23 @@ function makeSetup(intoStream) {
 const setup = makeSetup(intoStream);
 setup.object = makeSetup(intoStream.object);
 
-test('get stream', async t => {
+test('get stream as utf8 from buffer', async t => {
 	const result = await getStream(fs.createReadStream('fixture'));
 	t.is(result, fixtureString);
 });
 
-test('get stream as a buffer', async t => {
+test('get stream as utf8 from utf8', async t => {
+	const result = await getStream(fs.createReadStream('fixture', 'utf8'));
+	t.is(result, fixtureString);
+});
+
+test('get stream as a buffer from buffer', async t => {
 	const result = await getStreamAsBuffer(fs.createReadStream('fixture'));
+	t.true(result.equals(fixtureBuffer));
+});
+
+test('get stream as a buffer from utf8', async t => {
+	const result = await getStreamAsBuffer(fs.createReadStream('fixture', 'utf8'));
 	t.true(result.equals(fixtureBuffer));
 });
 


### PR DESCRIPTION
It seems to me the `PassThrough` stream's sole purpose is to change the encoding, according to the `encoding` option. Please let me know if that assumption is incorrect. If not, it can be skipped if the encoding does not change.