### PR TITLE
Remove a `devDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 	"devDependencies": {
 		"@types/node": "^20.2.4",
 		"ava": "^5.3.0",
-		"into-stream": "^8.0.0",
 		"tsd": "^0.28.1",
 		"xo": "^0.54.2"
 	}


### PR DESCRIPTION
The `compose()` or `Duplex.from()` methods can now be used in Node 16 instead of the `into-stream` dependency. This PR removes that `devDependency`.