### PR TITLE
Truncate `error.bufferedData` if too large

### DIFF
--- a/test.js
+++ b/test.js
@@ -78,7 +78,8 @@ test.serial('handles streams larger than buffer max length', async t => {
 	const chunkCount = Math.floor(BufferConstants.MAX_LENGTH / chunkSize * 2);
 	const chunk = Buffer.alloc(chunkSize);
 	const chunks = Array.from({length: chunkCount}, () => chunk);
-	await t.throwsAsync(setupBuffer(chunks));
+	const {bufferedData} = await t.throwsAsync(setupBuffer(chunks));
+	t.is(bufferedData[0], 0);
 });
 
 test.serial('handles streams larger than string max length', async t => {
@@ -87,7 +88,8 @@ test.serial('handles streams larger than string max length', async t => {
 	const chunkCount = Math.floor(BufferConstants.MAX_STRING_LENGTH / chunkSize * 2);
 	const chunk = '.'.repeat(chunkSize);
 	const chunks = Array.from({length: chunkCount}, () => chunk);
-	await t.throwsAsync(setup(chunks));
+	const {bufferedData} = await t.throwsAsync(setup(chunks));
+	t.is(bufferedData[0], '.');
 });
 
 // Tests related to big buffers/strings can be slow. We run them serially and


### PR DESCRIPTION
When `error.bufferedData` is too large, it is not set instead.
With this PR, `error.bufferedData` is still set, but with a smaller string/buffer. If the stream is too large, having the first bytes of it can prove to be very useful for debugging.