### PR TITLE
Improve TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {type Stream} from 'node:stream';
+import {type Readable} from 'node:stream';
 import {type Buffer} from 'node:buffer';
 
 export class MaxBufferError extends Error {
@@ -49,7 +49,7 @@ console.log(await getStream(stream));
 //                                     ~~
 ```
 */
-export default function getStream(stream: Stream, options?: Options): Promise<string>;
+export default function getStream(stream: Readable, options?: Options): Promise<string>;
 
 /**
 Get the given `stream` as a buffer.
@@ -65,4 +65,4 @@ const stream = fs.createReadStream('unicorn.png');
 console.log(await getStreamAsBuffer(stream));
 ```
 */
-export function getStreamAsBuffer(stream: Stream, options?: Options): Promise<Buffer>;
+export function getStreamAsBuffer(stream: Readable, options?: Options): Promise<Buffer>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,16 +1,23 @@
 import {type Buffer} from 'node:buffer';
-import {type Stream} from 'node:stream';
+import {type Readable} from 'node:stream';
 import fs from 'node:fs';
-import {expectType} from 'tsd';
+import {expectType, expectError} from 'tsd';
 import getStream, {getStreamAsBuffer, MaxBufferError} from './index.js';
 
-const stream = fs.createReadStream('foo') as Stream;
+const nodeStream = fs.createReadStream('foo') as Readable;
 
-expectType<Promise<string>>(getStream(stream));
-expectType<Promise<string>>(getStream(stream, {maxBuffer: 10}));
+expectType<string>(await getStream(nodeStream));
+expectType<string>(await getStream(nodeStream, {maxBuffer: 10}));
+expectError(await getStream({}));
+expectError(await getStream(nodeStream, {maxBuffer: '10'}));
+expectError(await getStream(nodeStream, {unknownOption: 10}));
+expectError(await getStream(nodeStream, {maxBuffer: 10}, {}));
 
-expectType<Promise<Buffer>>(getStreamAsBuffer(stream));
-expectType<Promise<Buffer>>(getStreamAsBuffer(stream, {maxBuffer: 10}));
+expectType<Buffer>(await getStreamAsBuffer(nodeStream));
+expectType<Buffer>(await getStreamAsBuffer(nodeStream, {maxBuffer: 10}));
+expectError(await getStreamAsBuffer({}));
+expectError(await getStreamAsBuffer(nodeStream, {maxBuffer: '10'}));
+expectError(await getStreamAsBuffer(nodeStream, {unknownOption: 10}));
+expectError(await getStreamAsBuffer(nodeStream, {maxBuffer: 10}, {}));
 
-const maxBufferError = new MaxBufferError();
-expectType<MaxBufferError>(maxBufferError);
+expectType<MaxBufferError>(new MaxBufferError());


### PR DESCRIPTION
This PR adds more tests for the TypeScript types.
It also make the types stricter by only allowing `Readable` streams, instead of any Node.js streams.