### PR TITLE
Improve first argument's validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ export default async function getStream(stream, options) {
 }
 
 const getStreamContents = async (stream, {convertChunk, getContents}, {maxBuffer = Number.POSITIVE_INFINITY} = {}) => {
-	if (!stream) {
-		throw new Error('Expected a stream');
+	if (!isAsyncIterable(stream)) {
+		throw new Error('The first argument must be a Readable.');
 	}
 
 	let length = 0;
@@ -41,6 +41,8 @@ const getStreamContents = async (stream, {convertChunk, getContents}, {maxBuffer
 		throw error;
 	}
 };
+
+const isAsyncIterable = stream => typeof stream === 'object' && stream !== null && typeof stream[Symbol.asyncIterator] === 'function';
 
 const getBufferedData = (chunks, getContents, length) => {
 	try {

--- a/test.js
+++ b/test.js
@@ -102,6 +102,15 @@ test('handles streams with a single chunk larger than string max length', async 
 	t.is(bufferedData, '');
 });
 
+const firstArgumentCheck = async (t, firstArgument) => {
+	await t.throwsAsync(getStream(firstArgument), {message: /first argument/});
+};
+
+test('Throws if the first argument is undefined', firstArgumentCheck, undefined);
+test('Throws if the first argument is null', firstArgumentCheck, null);
+test('Throws if the first argument is a string', firstArgumentCheck, '');
+test('Throws if the first argument is an array', firstArgumentCheck, []);
+
 test('native string', async t => {
 	const result = await text(compose(fixtureString));
 	t.is(result, fixtureString);


### PR DESCRIPTION
The current logic only checks whether the `stream` argument is passed. This PR adds validation to ensure it is a stream.