### PR TITLE
Add support for `DataView` stream chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,9 +61,12 @@ const getChunkType = chunk => {
 
 	const prototypeName = objectToString.call(chunk);
 
+	if (prototypeName === '[object DataView]') {
+		return 'dataView';
+	}
+
 	if (
-		prototypeName !== '[object DataView]'
-		&& Number.isInteger(chunk.byteLength)
+		Number.isInteger(chunk.byteLength)
 		&& Number.isInteger(chunk.byteOffset)
 		&& objectToString.call(chunk.buffer) === '[object ArrayBuffer]'
 	) {
@@ -120,6 +123,7 @@ const chunkTypes = {
 		convertChunk: {
 			string: useBufferFrom,
 			buffer: identity,
+			dataView: useBufferFromWithOffset,
 			typedArray: useBufferFromWithOffset,
 			others: throwObjectStream,
 		},
@@ -129,6 +133,7 @@ const chunkTypes = {
 		convertChunk: {
 			string: identity,
 			buffer: useTextDecoder,
+			dataView: useTextDecoder,
 			typedArray: useTextDecoder,
 			others: throwObjectStream,
 		},

--- a/test.js
+++ b/test.js
@@ -13,18 +13,21 @@ const fixtureBuffer = Buffer.from(fixtureString);
 const fixtureTypedArray = new TextEncoder().encode(fixtureString);
 const fixtureArrayBuffer = fixtureTypedArray.buffer;
 const fixtureUint16Array = new Uint16Array(fixtureArrayBuffer);
+const fixtureDataView = new DataView(fixtureArrayBuffer);
 
 const fixtureStringWide = `  ${fixtureString}  `;
 const fixtureTypedArrayWide = new TextEncoder().encode(fixtureStringWide);
 const fixtureArrayBufferWide = fixtureTypedArrayWide.buffer;
 const fixtureTypedArrayWithOffset = new Uint8Array(fixtureArrayBufferWide, 2, fixtureString.length);
 const fixtureUint16ArrayWithOffset = new Uint16Array(fixtureArrayBufferWide, 2, fixtureString.length / 2);
+const fixtureDataViewWithOffset = new DataView(fixtureArrayBufferWide, 2, fixtureString.length);
 
 const longString = `${fixtureString}..`;
 const longBuffer = Buffer.from(longString);
 const longTypedArray = new TextEncoder().encode(longString);
 const longArrayBuffer = longTypedArray.buffer;
 const longUint16Array = new Uint16Array(longArrayBuffer);
+const longDataView = new DataView(longArrayBuffer);
 const maxBuffer = fixtureString.length;
 
 const setup = (streamDef, options) => getStream(createStream(streamDef), options);
@@ -50,6 +53,8 @@ test('get stream from typedArray to string', getStreamToString, fixtureTypedArra
 test('get stream from typedArray with offset to string', getStreamToString, fixtureTypedArrayWithOffset);
 test('get stream from uint16Array to string', getStreamToString, fixtureUint16Array);
 test('get stream from uint16Array with offset to string', getStreamToString, fixtureUint16ArrayWithOffset);
+test('get stream from dataView to string', getStreamToString, fixtureDataView);
+test('get stream from dataView with offset to string', getStreamToString, fixtureDataViewWithOffset);
 
 const getStreamToBuffer = async (t, inputStream) => {
 	const result = await setupBuffer([inputStream]);
@@ -63,6 +68,8 @@ test('get stream from typedArray to buffer', getStreamToBuffer, fixtureTypedArra
 test('get stream from typedArray with offset to buffer', getStreamToBuffer, fixtureTypedArrayWithOffset);
 test('get stream from uint16Array to buffer', getStreamToBuffer, fixtureUint16Array);
 test('get stream from uint16Array with offset to buffer', getStreamToBuffer, fixtureUint16ArrayWithOffset);
+test('get stream from dataView to buffer', getStreamToBuffer, fixtureDataView);
+test('get stream from dataView with offset to buffer', getStreamToBuffer, fixtureDataViewWithOffset);
 
 const throwOnInvalidChunkType = async (t, setupFunction, inputStream) => {
 	await t.throwsAsync(setupFunction([inputStream]), {message: /not supported/});
@@ -119,6 +126,7 @@ test('maxBuffer throws when size is exceeded with a string', checkMaxBuffer, set
 test('maxBuffer throws when size is exceeded with a buffer', checkMaxBuffer, setupBuffer, longBuffer, fixtureBuffer);
 test('maxBuffer throws when size is exceeded with a typedArray', checkMaxBuffer, setupBuffer, longTypedArray, fixtureTypedArray);
 test('maxBuffer throws when size is exceeded with an uint16Array', checkMaxBuffer, setupBuffer, longUint16Array, fixtureUint16Array);
+test('maxBuffer throws when size is exceeded with a dataView', checkMaxBuffer, setupBuffer, longDataView, fixtureDataView);
 
 test('set error.bufferedData when `maxBuffer` is hit', async t => {
 	const error = await t.throwsAsync(setup([longString], {maxBuffer}), {instanceOf: MaxBufferError});


### PR DESCRIPTION
This PR continues implementing support for web streams ([`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)). This PR allows stream chunks to be `DataView`s, in addition to the already supported `string`, `TypedArray`, and Node.js `Buffer`.