### PR TITLE
Add support for DataView stream chunks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ console.log(await getStream(stream));
 export default function getStream(stream: Readable, options?: Options): Promise<string>;
 
 /**
-Get the given `stream` as a buffer.
+Get the given `stream` as a Node.js [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer).
 
 @returns The stream's contents as a promise.
 
@@ -65,3 +65,18 @@ console.log(await getStreamAsBuffer(stream));
 ```
 */
 export function getStreamAsBuffer(stream: Readable, options?: Options): Promise<Buffer>;
+
+/**
+Get the given `stream` as an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
+
+@returns The stream's contents as a promise.
+
+@example
+```
+import {getStreamAsArrayBuffer} from 'get-stream';
+
+const {body: readableStream} = await fetch('https://example.com');
+console.log(await getStreamAsArrayBuffer(readableStream));
+```
+*/
+export function getStreamAsArrayBuffer(stream: Readable, options?: Options): Promise<ArrayBuffer>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,7 +2,7 @@ import {type Buffer} from 'node:buffer';
 import {type Readable} from 'node:stream';
 import fs from 'node:fs';
 import {expectType, expectError} from 'tsd';
-import getStream, {getStreamAsBuffer, MaxBufferError} from './index.js';
+import getStream, {getStreamAsBuffer, getStreamAsArrayBuffer, MaxBufferError} from './index.js';
 
 const nodeStream = fs.createReadStream('foo') as Readable;
 
@@ -19,5 +19,12 @@ expectError(await getStreamAsBuffer({}));
 expectError(await getStreamAsBuffer(nodeStream, {maxBuffer: '10'}));
 expectError(await getStreamAsBuffer(nodeStream, {unknownOption: 10}));
 expectError(await getStreamAsBuffer(nodeStream, {maxBuffer: 10}, {}));
+
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(nodeStream));
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(nodeStream, {maxBuffer: 10}));
+expectError(await getStreamAsArrayBuffer({}));
+expectError(await getStreamAsArrayBuffer(nodeStream, {maxBuffer: '10'}));
+expectError(await getStreamAsArrayBuffer(nodeStream, {unknownOption: 10}));
+expectError(await getStreamAsArrayBuffer(nodeStream, {maxBuffer: 10}, {}));
 
 expectType<MaxBufferError>(new MaxBufferError());

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # get-stream
 
-> Get a stream as a string or buffer
+> Get a stream as a string, Buffer or ArrayBuffer
 
 ## Features
 
@@ -59,13 +59,24 @@ Get the given `stream` as a string.
 
 ### getStreamAsBuffer(stream, options?)
 
-Get the given `stream` as a buffer.
+Get the given `stream` as a Node.js [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer).
 
 ```js
 import {getStreamAsBuffer} from 'get-stream';
 
 const stream = fs.createReadStream('unicorn.png');
 console.log(await getStreamAsBuffer(stream));
+```
+
+### getStreamAsArrayBuffer(stream, options?)
+
+Get the given `stream` as an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
+
+```js
+import {getStreamAsArrayBuffer} from 'get-stream';
+
+const {body: readableStream} = await fetch('https://example.com');
+console.log(await getStreamAsArrayBuffer(readableStream));
 ```
 
 #### options
@@ -81,7 +92,7 @@ Maximum length of the stream. If exceeded, the promise will be rejected with a `
 
 ## Errors
 
-If the stream errors, the returned promise will be rejected with the `error`. Any contents already read from the stream will be set to `error.bufferedData`, which is a `string` or a `Buffer` depending on the [method used](#api).
+If the stream errors, the returned promise will be rejected with the `error`. Any contents already read from the stream will be set to `error.bufferedData`, which is a `string`, a `Buffer` or an `ArrayBuffer` depending on the [method used](#api).
 
 ```js
 import getStream from 'get-stream';
@@ -100,7 +111,7 @@ If you do not need [`maxBuffer`](#maxbuffer) nor [`error.bufferedData`](#errors)
 
 ```js
 import fs from 'node:fs';
-import {text, buffer} from 'node:stream/consumers';
+import {text, buffer, arrayBuffer} from 'node:stream/consumers';
 
 const stream = fs.createReadStream('unicorn.txt', {encoding: 'utf8'});
 console.log(await text(stream))
@@ -112,11 +123,17 @@ or:
 console.log(await buffer(stream))
 ```
 
+or:
+
+```js
+console.log(await arrayBuffer(stream))
+```
+
 ## FAQ
 
 ### How is this different from [`concat-stream`](https://github.com/maxogden/concat-stream)?
 
-This module accepts a stream instead of being one and returns a promise instead of using a callback. The API is simpler and it only supports returning a string or buffer. It doesn't have a fragile type inference. You explicitly choose what you want. And it doesn't depend on the huge `readable-stream` package.
+This module accepts a stream instead of being one and returns a promise instead of using a callback. The API is simpler and it only supports returning a string, `Buffer` or an `ArrayBuffer`. It doesn't have a fragile type inference. You explicitly choose what you want. And it doesn't depend on the huge `readable-stream` package.
 
 ## Related
 


### PR DESCRIPTION
This PR continues implementing support for web streams (`ReadableStream`). This adds a `getStreamAsArrayBuffer()` method that is like `getStreamAsBuffer()` except it returns an `ArrayBuffer` instead of a Node.js `Buffer`.

This is more convenient for web streams, which use `ArrayBuffer` under-the-hood.

This is also useful for users who prefer `ArrayBuffer` over `Buffer` since `Buffer` is Node.js-specific while `ArrayBuffer` is available in any JavaScript environment.