### PR TITLE
Add support for `ReadableStream`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export class MaxBufferError extends Error {
 }
 
 type StreamItem = string | Buffer | ArrayBuffer | ArrayBufferView;
-type AnyStream = Readable | ReadableStream<StreamItem> | AsyncIterable<StreamItem>;
+export type AnyStream = Readable | ReadableStream<StreamItem> | AsyncIterable<StreamItem>;
 
 export type Options = {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,12 @@ console.log(await getStream(stream));
 //                                    \~\
 //                                     ~~
 ```
+
+@example
+```
+const {body: readableStream} = await fetch('https://example.com');
+console.log(await getStream(readableStream));
+```
 */
 export default function getStream(stream: AnyStream, options?: Options): Promise<string>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,9 @@ export class MaxBufferError extends Error {
 	constructor();
 }
 
+type StreamItem = string | Buffer | ArrayBuffer | ArrayBufferView;
+type AnyStream = Readable | ReadableStream<StreamItem> | AsyncIterable<StreamItem>;
+
 export type Options = {
 	/**
 	Maximum length of the stream. If exceeded, the promise will be rejected with a `MaxBufferError`.
@@ -49,7 +52,7 @@ console.log(await getStream(stream));
 //                                     ~~
 ```
 */
-export default function getStream(stream: Readable, options?: Options): Promise<string>;
+export default function getStream(stream: AnyStream, options?: Options): Promise<string>;
 
 /**
 Get the given `stream` as a Node.js [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer).
@@ -64,7 +67,7 @@ const stream = fs.createReadStream('unicorn.png');
 console.log(await getStreamAsBuffer(stream));
 ```
 */
-export function getStreamAsBuffer(stream: Readable, options?: Options): Promise<Buffer>;
+export function getStreamAsBuffer(stream: AnyStream, options?: Options): Promise<Buffer>;
 
 /**
 Get the given `stream` as an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
@@ -79,4 +82,4 @@ const {body: readableStream} = await fetch('https://example.com');
 console.log(await getStreamAsArrayBuffer(readableStream));
 ```
 */
-export function getStreamAsArrayBuffer(stream: Readable, options?: Options): Promise<ArrayBuffer>;
+export function getStreamAsArrayBuffer(stream: AnyStream, options?: Options): Promise<ArrayBuffer>;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ export default async function getStream(stream, options) {
 
 const getStreamContents = async (stream, {convertChunk, getContents}, {maxBuffer = Number.POSITIVE_INFINITY} = {}) => {
 	if (!isAsyncIterable(stream)) {
-		throw new Error('The first argument must be a Readable, a ReadableStream or an async iterable.');
+		throw new Error('The first argument must be a Readable, a ReadableStream, or an async iterable.');
 	}
 
 	let length = 0;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ export default async function getStream(stream, options) {
 
 const getStreamContents = async (stream, {convertChunk, getContents}, {maxBuffer = Number.POSITIVE_INFINITY} = {}) => {
 	if (!isAsyncIterable(stream)) {
-		throw new Error('The first argument must be a Readable.');
+		throw new Error('The first argument must be a Readable, a ReadableStream or an async iterable.');
 	}
 
 	let length = 0;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,13 +1,34 @@
-import {type Buffer} from 'node:buffer';
-import {type Readable} from 'node:stream';
+import {Buffer} from 'node:buffer';
+import {open} from 'node:fs/promises';
+import {type Readable, Duplex} from 'node:stream';
 import fs from 'node:fs';
 import {expectType, expectError} from 'tsd';
 import getStream, {getStreamAsBuffer, getStreamAsArrayBuffer, MaxBufferError} from './index.js';
 
 const nodeStream = fs.createReadStream('foo') as Readable;
 
+const fileHandle = await open('test');
+const readableStream = fileHandle.readableWebStream();
+
+const asyncIterable = <T>(value: T): AsyncGenerator<T> => (async function * () {
+	yield value;
+})();
+const stringAsyncIterable = asyncIterable('');
+const bufferAsyncIterable = asyncIterable(Buffer.from(''));
+const arrayBufferAsyncIterable = asyncIterable(new ArrayBuffer(0));
+const dataViewAsyncIterable = asyncIterable(new DataView(new ArrayBuffer(0)));
+const typedArrayAsyncIterable = asyncIterable(new Uint8Array([]));
+const objectAsyncIterable = asyncIterable({});
+
 expectType<string>(await getStream(nodeStream));
 expectType<string>(await getStream(nodeStream, {maxBuffer: 10}));
+expectType<string>(await getStream(readableStream));
+expectType<string>(await getStream(stringAsyncIterable));
+expectType<string>(await getStream(bufferAsyncIterable));
+expectType<string>(await getStream(arrayBufferAsyncIterable));
+expectType<string>(await getStream(dataViewAsyncIterable));
+expectType<string>(await getStream(typedArrayAsyncIterable));
+expectError(await getStream(objectAsyncIterable));
 expectError(await getStream({}));
 expectError(await getStream(nodeStream, {maxBuffer: '10'}));
 expectError(await getStream(nodeStream, {unknownOption: 10}));
@@ -15,6 +36,13 @@ expectError(await getStream(nodeStream, {maxBuffer: 10}, {}));
 
 expectType<Buffer>(await getStreamAsBuffer(nodeStream));
 expectType<Buffer>(await getStreamAsBuffer(nodeStream, {maxBuffer: 10}));
+expectType<Buffer>(await getStreamAsBuffer(readableStream));
+expectType<Buffer>(await getStreamAsBuffer(stringAsyncIterable));
+expectType<Buffer>(await getStreamAsBuffer(bufferAsyncIterable));
+expectType<Buffer>(await getStreamAsBuffer(arrayBufferAsyncIterable));
+expectType<Buffer>(await getStreamAsBuffer(dataViewAsyncIterable));
+expectType<Buffer>(await getStreamAsBuffer(typedArrayAsyncIterable));
+expectError(await getStreamAsBuffer(objectAsyncIterable));
 expectError(await getStreamAsBuffer({}));
 expectError(await getStreamAsBuffer(nodeStream, {maxBuffer: '10'}));
 expectError(await getStreamAsBuffer(nodeStream, {unknownOption: 10}));
@@ -22,6 +50,13 @@ expectError(await getStreamAsBuffer(nodeStream, {maxBuffer: 10}, {}));
 
 expectType<ArrayBuffer>(await getStreamAsArrayBuffer(nodeStream));
 expectType<ArrayBuffer>(await getStreamAsArrayBuffer(nodeStream, {maxBuffer: 10}));
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(readableStream));
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(stringAsyncIterable));
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(bufferAsyncIterable));
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(arrayBufferAsyncIterable));
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(dataViewAsyncIterable));
+expectType<ArrayBuffer>(await getStreamAsArrayBuffer(typedArrayAsyncIterable));
+expectError(await getStreamAsArrayBuffer(objectAsyncIterable));
 expectError(await getStreamAsArrayBuffer({}));
 expectError(await getStreamAsArrayBuffer(nodeStream, {maxBuffer: '10'}));
 expectError(await getStreamAsArrayBuffer(nodeStream, {unknownOption: 10}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,9 +1,9 @@
 import {Buffer} from 'node:buffer';
 import {open} from 'node:fs/promises';
-import {type Readable, Duplex} from 'node:stream';
+import {type Readable} from 'node:stream';
 import fs from 'node:fs';
-import {expectType, expectError} from 'tsd';
-import getStream, {getStreamAsBuffer, getStreamAsArrayBuffer, MaxBufferError} from './index.js';
+import {expectType, expectError, expectAssignable, expectNotAssignable} from 'tsd';
+import getStream, {getStreamAsBuffer, getStreamAsArrayBuffer, MaxBufferError, type Options, type AnyStream} from './index.js';
 
 const nodeStream = fs.createReadStream('foo') as Readable;
 
@@ -61,5 +61,18 @@ expectError(await getStreamAsArrayBuffer({}));
 expectError(await getStreamAsArrayBuffer(nodeStream, {maxBuffer: '10'}));
 expectError(await getStreamAsArrayBuffer(nodeStream, {unknownOption: 10}));
 expectError(await getStreamAsArrayBuffer(nodeStream, {maxBuffer: 10}, {}));
+
+expectAssignable<AnyStream>(nodeStream);
+expectAssignable<AnyStream>(readableStream);
+expectAssignable<AnyStream>(stringAsyncIterable);
+expectAssignable<AnyStream>(bufferAsyncIterable);
+expectAssignable<AnyStream>(arrayBufferAsyncIterable);
+expectAssignable<AnyStream>(dataViewAsyncIterable);
+expectAssignable<AnyStream>(typedArrayAsyncIterable);
+expectNotAssignable<AnyStream>({});
+
+expectAssignable<Options>({maxBuffer: 10});
+expectNotAssignable<Options>({maxBuffer: '10'});
+expectNotAssignable<Options>({unknownOption: 10});
 
 expectType<MaxBufferError>(new MaxBufferError());

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ The following methods read the stream's contents and return it as a promise.
 
 ### getStream(stream, options?)
 
-`stream`: [`stream.Readable`](https://nodejs.org/api/stream.html#class-streamreadable), [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [`AsyncIterable<string | Buffer | ArrayBuffer | DataView | TypedArray>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)\
+`stream`: [`stream.Readable`](https://nodejs.org/api/stream.html#class-streamreadable), [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream), or [`AsyncIterable<string | Buffer | ArrayBuffer | DataView | TypedArray>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)\
 `options`: [`Options`](#options)
 
 Get the given `stream` as a string.

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ npm install get-stream
 
 ## Usage
 
+### Node.js streams
+
 ```js
 import fs from 'node:fs';
 import getStream from 'get-stream';
@@ -46,13 +48,20 @@ console.log(await getStream(stream));
 */
 ```
 
+### Web streams
+
+```js
+const {body: readableStream} = await fetch('https://example.com');
+console.log(await getStream(readableStream));
+```
+
 ## API
 
 The following methods read the stream's contents and return it as a promise.
 
 ### getStream(stream, options?)
 
-`stream`: [`stream.Readable`](https://nodejs.org/api/stream.html#class-streamreadable)
+`stream`: [`stream.Readable`](https://nodejs.org/api/stream.html#class-streamreadable), [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) or [`AsyncIterable<string | Buffer | ArrayBuffer | DataView | TypedArray>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)\
 `options`: [`Options`](#options)
 
 Get the given `stream` as a string.


### PR DESCRIPTION
This adds support for web/Node.js `ReadableStream`s.

This also adds support for any async iterable as input, since this is the common denominator between Node.js streams and web `ReadableStream` (which we just consume with a `for await` loop).