### PR TITLE
Small performance improvement

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,11 +51,13 @@ const getStreamContents = async (stream, {convertChunk, getContents}, {maxBuffer
 const isAsyncIterable = stream => typeof stream === 'object' && stream !== null && typeof stream[Symbol.asyncIterator] === 'function';
 
 const getChunkType = chunk => {
-	if (typeof chunk === 'string') {
+	const typeOfChunk = typeof chunk;
+
+	if (typeOfChunk === 'string') {
 		return 'string';
 	}
 
-	if (typeof chunk !== 'object' || chunk === null) {
+	if (typeOfChunk !== 'object' || chunk === null) {
 		return 'others';
 	}
 


### PR DESCRIPTION
I was doing some performance tuning and it turns out calling `typeof` on each chunk is actually in the hot path of `get-stream`. Calling it only once slightly improves the performance.