### PR TITLE
Support any JavaScript environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-import {Buffer} from 'node:buffer';
-
 export class MaxBufferError extends Error {
 	name = 'MaxBufferError';
 
@@ -9,6 +7,10 @@ export class MaxBufferError extends Error {
 }
 
 export async function getStreamAsBuffer(stream, options) {
+	if (!('Buffer' in globalThis)) {
+		throw new Error('getStreamAsBuffer() is only supported in Node.js');
+	}
+
 	return getStreamContents(stream, chunkTypes.buffer, options);
 }
 
@@ -61,7 +63,8 @@ const getChunkType = chunk => {
 		return 'others';
 	}
 
-	if (Buffer.isBuffer(chunk)) {
+	// eslint-disable-next-line n/prefer-global/buffer
+	if (globalThis.Buffer?.isBuffer(chunk)) {
 		return 'buffer';
 	}
 
@@ -118,11 +121,14 @@ const throwObjectStream = chunk => {
 	throw new Error(`Streams in object mode are not supported: ${String(chunk)}`);
 };
 
-const useBufferFrom = chunk => Buffer.from(chunk);
+// eslint-disable-next-line n/prefer-global/buffer
+const useBufferFrom = chunk => globalThis.Buffer.from(chunk);
 
-const useBufferFromWithOffset = chunk => Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+// eslint-disable-next-line n/prefer-global/buffer
+const useBufferFromWithOffset = chunk => globalThis.Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
 
-const getContentsAsBuffer = (chunks, textDecoder, length) => Buffer.concat(chunks, length);
+// eslint-disable-next-line n/prefer-global/buffer
+const getContentsAsBuffer = (chunks, textDecoder, length) => globalThis.Buffer.concat(chunks, length);
 
 const useTextEncoder = chunk => textEncoder.encode(chunk);
 const textEncoder = new TextEncoder();

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 
 ## Features
 
+- Works in any JavaScript environment ([Node.js](#nodejs-streams), [browsers](#web-streams), etc.).
 - Supports both [text streams](#get-stream) and [binary streams](#getstreamasbufferstream-options).
 - Can set a [maximum stream size](#maxbuffer).
 - Returns [partially read data](#errors) when the stream errors.
@@ -116,7 +117,7 @@ try {
 
 ## Tip
 
-If you do not need [`maxBuffer`](#maxbuffer) nor [`error.bufferedData`](#errors), you can use [`node:stream/consumers`](https://nodejs.org/api/webstreams.html#utility-consumers) instead of this package.
+If you do not need [`maxBuffer`](#maxbuffer), [`error.bufferedData`](#errors) nor browser support, you can use [`node:stream/consumers`](https://nodejs.org/api/webstreams.html#utility-consumers) instead of this package.
 
 ```js
 import fs from 'node:fs';


### PR DESCRIPTION
`get-stream` does not depend on any Node.js specific imports anymore, with the exception of `Buffer`.
`Buffer` is only used with `getStreamAsBuffer()`. `getStreamAsArrayBuffer()` can be used instead as an alternative that does not rely on Node.js `Buffer`.

This PR uses `Buffer` through `globalThis.Buffer` instead of `import { Buffer } from 'node:buffer'` to make it simpler for any JavaScript environment to use `get-stream` (without any bundler nor shims). It does not remove `Buffer` support, since this is still useful in a Node.js context.

This makes `get-stream` now available in any JavaScript environment.