### PR TITLE
Fix `bufferedData` being larger than `maxBuffer`

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,13 @@ const getStreamContents = async (stream, {convertChunk, getSize, getContents}, {
 		for await (const chunk of stream) {
 			const chunkType = getChunkType(chunk);
 			const convertedChunk = convertChunk[chunkType](chunk, textDecoder);
-			length += getSize(convertedChunk);
+			const chunkSize = getSize(convertedChunk);
 
-			if (length > maxBuffer) {
+			if (length + chunkSize > maxBuffer) {
 				throw new MaxBufferError();
 			}
 
+			length += chunkSize;
 			chunks.push(convertedChunk);
 		}
 

--- a/index.js
+++ b/index.js
@@ -39,12 +39,13 @@ const getStreamContents = async (stream, {convertChunk, getSize, getContents}, {
 		for await (const chunk of stream) {
 			const chunkType = getChunkType(chunk);
 			const convertedChunk = convertChunk[chunkType](chunk, textDecoder);
-			chunks.push(convertedChunk);
 			length += getSize(convertedChunk);
 
 			if (length > maxBuffer) {
 				throw new MaxBufferError();
 			}
+
+			chunks.push(convertedChunk);
 		}
 
 		return getContents(chunks, textDecoder, length);

--- a/test.js
+++ b/test.js
@@ -210,8 +210,10 @@ test('maxBuffer unit is bytes with getStreamAsArrayBuffer()', checkMaxBuffer, se
 test('maxBuffer unit is each array element with getStreamAsArray()', checkMaxBuffer, setupArray, longArray, fixtureArray, fixtureArray.length);
 
 test('set error.bufferedData when `maxBuffer` is hit', async t => {
-	const error = await t.throwsAsync(setup([longString], {maxBuffer: fixtureLength}), {instanceOf: MaxBufferError});
-	t.is(error.bufferedData, longString);
+	const maxBuffer = fixtureLength - 1;
+	const {bufferedData} = await t.throwsAsync(setup([...fixtureString], {maxBuffer}), {instanceOf: MaxBufferError});
+	t.true(fixtureString.startsWith(bufferedData));
+	t.true(bufferedData.length <= maxBuffer);
 });
 
 const errorStream = async function * () {

--- a/test.js
+++ b/test.js
@@ -211,8 +211,8 @@ test('maxBuffer unit is each array element with getStreamAsArray()', checkMaxBuf
 
 test('set error.bufferedData when `maxBuffer` is hit', async t => {
 	const maxBuffer = fixtureLength - 1;
-	const {bufferedData} = await t.throwsAsync(setup([...fixtureString], {maxBuffer}), {instanceOf: MaxBufferError});
-	t.true(fixtureString.startsWith(bufferedData));
+	const {bufferedData} = await t.throwsAsync(setupBuffer([...fixtureString], {maxBuffer}), {instanceOf: MaxBufferError});
+	t.true(fixtureString.startsWith(bufferedData.toString()));
 	t.true(bufferedData.length <= maxBuffer);
 });
 


### PR DESCRIPTION
`error.bufferedData` should be limited by `options.maxBuffer`, just like the return value is. This PR fixes this.