### PR TITLE
Remove end-of-stream blocking

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,8 @@ const finalizeArrayBuffer = ({buffer}, length) => hasArrayBufferResize() ? buffe
 // (Node >=20.0.0, Safari >=16.4 and Chrome), we can use it instead.
 // eslint-disable-next-line no-warning-comments
 // TODO: remove after dropping support for Node 20.
+// eslint-disable-next-line no-warning-comments
+// TODO: use `ArrayBuffer.transferToFixedLength()` instead once it is available
 const hasArrayBufferResize = () => 'resize' in ArrayBuffer.prototype;
 
 const initString = () => '';

--- a/index.js
+++ b/index.js
@@ -178,8 +178,9 @@ const SCALE_FACTOR = 2;
 
 const finalizeArrayBuffer = ({buffer}, length) => hasArrayBufferResize() ? buffer : buffer.slice(0, length);
 
-// TODO: `ArrayBuffer.slice()` is slow. When `ArrayBuffer.resize()` is available
+// `ArrayBuffer.slice()` is slow. When `ArrayBuffer.resize()` is available
 // (Node >=20.0.0, Safari >=16.4 and Chrome), we can use it instead.
+// TODO: remove after dropping support for Node 20.
 const hasArrayBufferResize = () => 'resize' in ArrayBuffer.prototype;
 
 const initString = () => '';

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ const SCALE_FACTOR = 2;
 
 const finalizeArrayBuffer = ({buffer}, length) => hasArrayBufferResize() ? buffer : buffer.slice(0, length);
 
-// `ArrayBuffer.slice()` is slow. When `ArrayBuffer.resize()` is available
+// TODO: `ArrayBuffer.slice()` is slow. When `ArrayBuffer.resize()` is available
 // (Node >=20.0.0, Safari >=16.4 and Chrome), we can use it instead.
 const hasArrayBufferResize = () => 'resize' in ArrayBuffer.prototype;
 

--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ const finalizeArrayBuffer = ({buffer}, length) => hasArrayBufferResize() ? buffe
 
 // `ArrayBuffer.slice()` is slow. When `ArrayBuffer.resize()` is available
 // (Node >=20.0.0, Safari >=16.4 and Chrome), we can use it instead.
+// eslint-disable-next-line no-warning-comments
 // TODO: remove after dropping support for Node 20.
 const hasArrayBufferResize = () => 'resize' in ArrayBuffer.prototype;
 

--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ const getStreamContents = async (stream, {init, convertChunk, getSize, addChunk,
 				throw new MaxBufferError();
 			}
 
-			const previousLength = length;
-			length += chunkSize;
-			contents = addChunk(convertedChunk, contents, length, previousLength);
+			const newLength = length + chunkSize;
+			contents = addChunk(convertedChunk, contents, newLength, length);
+			length = newLength;
 		}
 
 		return finalize(contents, length, textDecoder);

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ const useUint8ArrayWithOffset = chunk => new Uint8Array(chunk.buffer, chunk.byte
 
 // `contents` is an increasingly growing `Uint8Array`.
 const addArrayBufferChunk = (convertedChunk, contents, length, previousLength) => {
-	const newContents = hasArrayBufferResize() ? resizeArrayBufferFast(contents, length) : resizeArrayBuffer(contents, length);
+	const newContents = hasArrayBufferResize() ? resizeArrayBuffer(contents, length) : resizeArrayBufferSlow(contents, length);
 	newContents.set(convertedChunk, previousLength);
 	return newContents;
 };
@@ -145,7 +145,7 @@ const addArrayBufferChunk = (convertedChunk, contents, length, previousLength) =
 // Without `ArrayBuffer.resize()`, `contents` size is always a power of 2.
 // This means its last bytes are zeroes (not stream data), which need to be
 // trimmed at the end with `ArrayBuffer.slice()`.
-const resizeArrayBuffer = (contents, length) => {
+const resizeArrayBufferSlow = (contents, length) => {
 	if (length <= contents.length) {
 		return contents;
 	}
@@ -159,7 +159,7 @@ const resizeArrayBuffer = (contents, length) => {
 // the stream data. It does not include extraneous zeroes to trim at the end.
 // The underlying `ArrayBuffer` does allocate a number of bytes that is a power
 // of 2, but those bytes are only visible after calling `ArrayBuffer.resize()`.
-const resizeArrayBufferFast = (contents, length) => {
+const resizeArrayBuffer = (contents, length) => {
 	if (length <= contents.buffer.maxByteLength) {
 		contents.buffer.resize(length);
 		return new Uint8Array(contents.buffer, 0, length);

--- a/test.js
+++ b/test.js
@@ -387,9 +387,6 @@ if (!nodeVersion.startsWith('v16.')) {
 	});
 
 	test('can use TextDecoderStream', async t => {
-		// eslint-disable-next-line no-warning-comments
-		// TODO: Remove the following comment when dropping support for Node 16
-		// eslint-disable-next-line no-undef
 		const textDecoderStream = new TextDecoderStream('utf-16le');
 		const result = await getStream(
 			createReadableStream(fixtureUtf16).pipeThrough(textDecoderStream),

--- a/test.js
+++ b/test.js
@@ -387,7 +387,8 @@ if (!nodeVersion.startsWith('v16.')) {
 	});
 
 	test('can use TextDecoderStream', async t => {
-		// @todo Remove the following comment when dropping support for Node 16
+		// eslint-disable-next-line no-warning-comments
+		// TODO: Remove the following comment when dropping support for Node 16
 		// eslint-disable-next-line no-undef
 		const textDecoderStream = new TextDecoderStream('utf-16le');
 		const result = await getStream(

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import {setTimeout} from 'node:timers/promises';
 import {spawn} from 'node:child_process';
 import {createReadStream} from 'node:fs';
 import {open} from 'node:fs/promises';
-import {version as nodeVersion, env} from 'node:process';
+import {version as nodeVersion} from 'node:process';
 import {Duplex} from 'node:stream';
 import {text, buffer, arrayBuffer} from 'node:stream/consumers';
 import test from 'ava';
@@ -297,23 +297,17 @@ const getMaxStringChunks = () => {
 const maxBufferChunks = getMaxBufferChunks();
 const maxStringChunks = getMaxStringChunks();
 
-// Running this test works locally but makes `ava` process crash when run in
-// GitHub actions. Unfortunately, the test requires building a very large
-// `ArrayBuffer` in order to test how `get-stream` handles it, so there is no
-// way around this but to keep the following test local-only.
-if (!env.CI) {
-	test.serial('handles streams larger than arrayBuffer max length', async t => {
-		t.timeout(BIG_TEST_DURATION);
-		const {bufferedData} = await t.throwsAsync(setupArrayBuffer(maxBufferChunks));
-		t.is(new Uint8Array(bufferedData)[0], 0);
-	});
+test.serial('handles streams larger than arrayBuffer max length', async t => {
+	t.timeout(BIG_TEST_DURATION);
+	const {bufferedData} = await t.throwsAsync(setupArrayBuffer(maxBufferChunks));
+	t.is(new Uint8Array(bufferedData)[0], 0);
+});
 
-	test.serial('handles streams larger than buffer max length', async t => {
-		t.timeout(BIG_TEST_DURATION);
-		const {bufferedData} = await t.throwsAsync(setupBuffer(maxBufferChunks));
-		t.is(bufferedData[0], 0);
-	});
-}
+test.serial('handles streams larger than buffer max length', async t => {
+	t.timeout(BIG_TEST_DURATION);
+	const {bufferedData} = await t.throwsAsync(setupBuffer(maxBufferChunks));
+	t.is(bufferedData[0], 0);
+});
 
 test.serial('handles streams larger than string max length', async t => {
 	t.timeout(BIG_TEST_DURATION);


### PR DESCRIPTION
Currently, `get-stream` aggregates all chunks in an array. Once fully consumed, all chunks are concatenated at the end. 

This final concatenation is slow and CPU-bound. On my machine, for `getStream()`, it is roughly a third of the CPU time spent. It is even half of it for `getStreamAsBuffer()`/`getStreamAsArrayBuffer()`. If that final concatenation is happening on a big stream, this can hold up the event loop for a relatively long time. This can result in perceivable freezes by users, which removes some of the benefits of using streams.

Instead, this PR finds a way to remove that final concatenation, and spend that CPU time when each chunk is processed instead. In other terms, it spreads that load over the whole time the stream is being consumed. Since streams are almost always I/O-bound (filesystem or network), that additional CPU time spent on each chunk is not noticed since the bottleneck is I/O (i.e. waiting for the next chunk).

This PR implements this by shifting the main strategy from storing each chunk in an array, to computing the final value incrementally instead. For example, instead of pushing to an array of strings then calling `array.join('')`, it keeps only a single string, which is appended with `+=` on each chunk. This turns out to be actually ~30% faster (on my machine), most likely because `array.push()` needs to allocate more memory at specific size intervals, which is slow. As a side note, this is also how core Node.js [is implementing `text()`](https://github.com/nodejs/node/blob/7f2c810814d8e3c8e9dd69e5ac004ff1f70a7656/lib/stream/consumers.js#L62).

For `Buffer`/`ArrayBuffer`, the implementation is a little more involved to make sure it is as fast as possible (i.e. doing as few memory allocations and copies as possible). There are also two strategies, since [`ArrayBuffer.resize()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resize) provides with some significant performance boost, but is unfortunately only supported [in Node 20 and a couple of browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resize#browser_compatibility).

This PR comes also with the following enhancement: when the stream is so big that it is larger than the max length for a string/`Buffer`/`ArrayBuffer`, we currently truncate `error.bufferedData` to make sure it fits within the max length. The current implementation returns only half of `error.bufferedData`. This PR returns all bytes that have been read so far instead, so users will get as much information as possible in `error.bufferedData`.

Apart from that last point, the user-visible behavior is identical to before this PR, this is just performance tweaking.

Finally, spreading the load as described above seems to decrease the probability of the process crashing on big streams. 2 automated tests had been previously disabled on CI for this reason. This PR re-enables them on CI, as they now work correctly.