### PR TITLE
Fix `package.json` description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "get-stream",
 	"version": "7.0.1",
-	"description": "Get a stream as a string or buffer",
+	"description": "Get a stream as a string, Buffer, ArrayBuffer or array",
 	"license": "MIT",
 	"repository": "sindresorhus/get-stream",
 	"funding": "https://github.com/sponsors/sindresorhus",


### PR DESCRIPTION
This updates the `package.json` description to match the `readme.md`.
The repository's main description would need to be updated too (I cannot do it due to permissions).