### PR TITLE
Fix `maxBuffer` bug with `TextDecoder()`

### DIFF
--- a/source/array.js
+++ b/source/array.js
@@ -1,15 +1,15 @@
 import {getStreamContents} from './contents.js';
-import {identity} from './utils.js';
+import {identity, noop, getContentsProp} from './utils.js';
 
 export async function getStreamAsArray(stream, options) {
 	return getStreamContents(stream, arrayMethods, options);
 }
 
-const initArray = () => ([]);
+const initArray = () => ({contents: []});
 
 const increment = () => 1;
 
-const addArrayChunk = (convertedChunk, contents) => {
+const addArrayChunk = (convertedChunk, {contents}) => {
 	contents.push(convertedChunk);
 	return contents;
 };
@@ -26,5 +26,6 @@ const arrayMethods = {
 	},
 	getSize: increment,
 	addChunk: addArrayChunk,
-	finalize: identity,
+	getFinalChunk: noop,
+	finalize: getContentsProp,
 };

--- a/source/string.js
+++ b/source/string.js
@@ -1,17 +1,20 @@
 import {getStreamContents} from './contents.js';
-import {identity, throwObjectStream, getLengthProp} from './utils.js';
+import {identity, getContentsProp, throwObjectStream, getLengthProp} from './utils.js';
 
 export async function getStreamAsString(stream, options) {
 	return getStreamContents(stream, stringMethods, options);
 }
 
-const initString = () => '';
+const initString = () => ({contents: '', textDecoder: new TextDecoder()});
 
-const useTextDecoder = (chunk, textDecoder) => textDecoder.decode(chunk, {stream: true});
+const useTextDecoder = (chunk, {textDecoder}) => textDecoder.decode(chunk, {stream: true});
 
-const addStringChunk = (convertedChunk, contents) => contents + convertedChunk;
+const addStringChunk = (convertedChunk, {contents}) => contents + convertedChunk;
 
-const finalizeString = (contents, length, textDecoder) => `${contents}${textDecoder.decode()}`;
+const getFinalStringChunk = ({textDecoder}) => {
+	const finalChunk = textDecoder.decode();
+	return finalChunk === '' ? undefined : finalChunk;
+};
 
 const stringMethods = {
 	init: initString,
@@ -25,5 +28,6 @@ const stringMethods = {
 	},
 	getSize: getLengthProp,
 	addChunk: addStringChunk,
-	finalize: finalizeString,
+	getFinalChunk: getFinalStringChunk,
+	finalize: getContentsProp,
 };

--- a/source/utils.js
+++ b/source/utils.js
@@ -1,5 +1,9 @@
 export const identity = value => value;
 
+export const noop = () => undefined;
+
+export const getContentsProp = ({contents}) => contents;
+
 export const throwObjectStream = chunk => {
 	throw new Error(`Streams in object mode are not supported: ${String(chunk)}`);
 };

--- a/test/string.js
+++ b/test/string.js
@@ -112,6 +112,11 @@ test('get stream with truncated UTF-8 sequences', async t => {
 	t.is(result, `${multiByteString.slice(0, -1)}${INVALID_UTF8_MARKER}`);
 });
 
+test('handles truncated UTF-8 sequences over maxBuffer', async t => {
+	const maxBuffer = multiByteString.length - 1;
+	await t.throwsAsync(setupString(multiByteBuffer.slice(0, -1), {maxBuffer}), {instanceOf: MaxBufferError});
+});
+
 test('get stream with invalid UTF-8 sequences', async t => {
 	const result = await setupString(multiByteBuffer.slice(1, 2));
 	t.is(result, INVALID_UTF8_MARKER);


### PR DESCRIPTION
If the stream contains a UTF-8 string with a partial multibyte sequence at the end, a final character `\ufffd` (`�`) is appended. This is the standard behavior by `TextDecoder` and other tools.

At the moment, this final byte is not checked by the `maxBuffer` logic. I.e. the returned string could be one byte over `maxBuffer` when appending `�`.

This PR fixes this bug. This required some refactoring.