### PR TITLE
Ensure `error.bufferedData` is as full as possible

### DIFF
--- a/source/array-buffer.js
+++ b/source/array-buffer.js
@@ -14,6 +14,8 @@ const useUint8Array = chunk => new Uint8Array(chunk);
 
 const useUint8ArrayWithOffset = chunk => new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
 
+const truncateArrayBufferChunk = (convertedChunk, chunkSize) => convertedChunk.slice(0, chunkSize);
+
 // `contents` is an increasingly growing `Uint8Array`.
 const addArrayBufferChunk = (convertedChunk, {contents, length: previousLength}, length) => {
 	const newContents = hasArrayBufferResize() ? resizeArrayBuffer(contents, length) : resizeArrayBufferSlow(contents, length);
@@ -75,6 +77,7 @@ const arrayBufferMethods = {
 		others: throwObjectStream,
 	},
 	getSize: getLengthProp,
+	truncateChunk: truncateArrayBufferChunk,
 	addChunk: addArrayBufferChunk,
 	getFinalChunk: noop,
 	finalize: finalizeArrayBuffer,

--- a/source/array.js
+++ b/source/array.js
@@ -25,6 +25,7 @@ const arrayMethods = {
 		others: identity,
 	},
 	getSize: increment,
+	truncateChunk: noop,
 	addChunk: addArrayChunk,
 	getFinalChunk: noop,
 	finalize: getContentsProp,

--- a/source/string.js
+++ b/source/string.js
@@ -11,6 +11,8 @@ const useTextDecoder = (chunk, {textDecoder}) => textDecoder.decode(chunk, {stre
 
 const addStringChunk = (convertedChunk, {contents}) => contents + convertedChunk;
 
+const truncateStringChunk = (convertedChunk, chunkSize) => convertedChunk.slice(0, chunkSize);
+
 const getFinalStringChunk = ({textDecoder}) => {
 	const finalChunk = textDecoder.decode();
 	return finalChunk === '' ? undefined : finalChunk;
@@ -27,6 +29,7 @@ const stringMethods = {
 		others: throwObjectStream,
 	},
 	getSize: getLengthProp,
+	truncateChunk: truncateStringChunk,
 	addChunk: addStringChunk,
 	getFinalChunk: getFinalStringChunk,
 	finalize: getContentsProp,

--- a/test/array-buffer.js
+++ b/test/array-buffer.js
@@ -80,6 +80,26 @@ test('maxBuffer throws when size is exceeded with an uint16Array', checkMaxBuffe
 test('maxBuffer throws when size is exceeded with a dataView', checkMaxBuffer, longDataView, fixtureDataView, fixtureLength);
 test('maxBuffer unit is bytes with getStreamAsArrayBuffer()', checkMaxBuffer, longMultibyteUint16Array, fixtureMultibyteUint16Array, fixtureMultibyteUint16Array.byteLength);
 
+const checkBufferedData = async (t, fixtureValue, expectedResult) => {
+	const maxBuffer = expectedResult.byteLength;
+	const {bufferedData} = await t.throwsAsync(setupArrayBuffer(fixtureValue, {maxBuffer}), {instanceOf: MaxBufferError});
+	t.is(bufferedData.byteLength, maxBuffer);
+	t.deepEqual(expectedResult, bufferedData);
+};
+
+test(
+	'set error.bufferedData when `maxBuffer` is hit, with a single chunk',
+	checkBufferedData,
+	[fixtureArrayBuffer],
+	new Uint8Array(Buffer.from(fixtureString[0])).buffer,
+);
+test(
+	'set error.bufferedData when `maxBuffer` is hit, with multiple chunks',
+	checkBufferedData,
+	[fixtureArrayBuffer, fixtureArrayBuffer],
+	new Uint8Array(Buffer.from(`${fixtureString}${fixtureString[0]}`)).buffer,
+);
+
 test('handles streams larger than arrayBuffer max length', async t => {
 	t.timeout(BIG_TEST_DURATION);
 	const chunkCount = Math.floor(BufferConstants.MAX_LENGTH / CHUNK_SIZE * 2);

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -76,6 +76,26 @@ const checkMaxBuffer = async (t, longValue, shortValue, maxBuffer) => {
 test('maxBuffer throws when size is exceeded with a buffer', checkMaxBuffer, longBuffer, fixtureBuffer, fixtureLength);
 test('maxBuffer unit is bytes with getStreamAsBuffer()', checkMaxBuffer, longMultibyteBuffer, fixtureMultibyteBuffer, fixtureMultibyteBuffer.byteLength);
 
+const checkBufferedData = async (t, fixtureValue, expectedResult) => {
+	const maxBuffer = expectedResult.length;
+	const {bufferedData} = await t.throwsAsync(setupBuffer(fixtureValue, {maxBuffer}), {instanceOf: MaxBufferError});
+	t.is(bufferedData.length, maxBuffer);
+	t.deepEqual(expectedResult, bufferedData);
+};
+
+test(
+	'set error.bufferedData when `maxBuffer` is hit, with a single chunk',
+	checkBufferedData,
+	[fixtureBuffer],
+	fixtureBuffer.slice(0, 1),
+);
+test(
+	'set error.bufferedData when `maxBuffer` is hit, with multiple chunks',
+	checkBufferedData,
+	[fixtureBuffer, fixtureBuffer],
+	Buffer.from([...fixtureBuffer, ...fixtureBuffer.slice(0, 1)]),
+);
+
 test('getStreamAsBuffer() behaves like buffer()', async t => {
 	const [nativeResult, customResult] = await Promise.all([
 		buffer(createStream([bigBuffer])),

--- a/test/contents.js
+++ b/test/contents.js
@@ -9,7 +9,6 @@ import {
 	fixtureArrayBuffer,
 	fixtureUint16Array,
 	fixtureDataView,
-	fixtureLength,
 } from './fixtures/index.js';
 
 const setupString = (streamDef, options) => getStream(createStream(streamDef), options);
@@ -36,13 +35,6 @@ test('getStream should not affect additional listeners attached to the stream', 
 	const fixture = createStream(['foo', 'bar']);
 	fixture.on('data', chunk => t.true(typeof chunk === 'string'));
 	t.is(await getStream(fixture), 'foobar');
-});
-
-test('set error.bufferedData when `maxBuffer` is hit', async t => {
-	const maxBuffer = fixtureLength - 1;
-	const {bufferedData} = await t.throwsAsync(setupString([...fixtureString], {maxBuffer}), {instanceOf: MaxBufferError});
-	t.true(fixtureString.startsWith(bufferedData));
-	t.true(bufferedData.length <= maxBuffer);
 });
 
 const errorStream = async function * () {

--- a/test/string.js
+++ b/test/string.js
@@ -77,6 +77,26 @@ const checkMaxBuffer = async (t, longValue, shortValue, maxBuffer) => {
 test('maxBuffer throws when size is exceeded with a string', checkMaxBuffer, longString, fixtureString, fixtureLength);
 test('maxBuffer unit is characters with getStream()', checkMaxBuffer, longMultibyteString, fixtureMultibyteString, fixtureMultibyteString.length);
 
+const checkBufferedData = async (t, fixtureValue, expectedResult) => {
+	const maxBuffer = expectedResult.length;
+	const {bufferedData} = await t.throwsAsync(setupString(fixtureValue, {maxBuffer}), {instanceOf: MaxBufferError});
+	t.is(bufferedData.length, maxBuffer);
+	t.is(expectedResult, bufferedData);
+};
+
+test(
+	'set error.bufferedData when `maxBuffer` is hit, with a single chunk',
+	checkBufferedData,
+	[fixtureString],
+	fixtureString[0],
+);
+test(
+	'set error.bufferedData when `maxBuffer` is hit, with multiple chunks',
+	checkBufferedData,
+	[fixtureString, fixtureString],
+	`${fixtureString}${fixtureString[0]}`,
+);
+
 test('handles streams larger than string max length', async t => {
 	t.timeout(BIG_TEST_DURATION);
 	const chunkCount = Math.floor(BufferConstants.MAX_STRING_LENGTH / CHUNK_SIZE * 2);


### PR DESCRIPTION
When the stream is larger than `maxBuffer`, the last chunk is currently missing from `error.bufferedData`, since it would make `error.bufferedData` larger than `maxBuffer`.

This PR adds the last chunk instead, but truncated so it fits within `maxBuffer`.

This has several advantages:
1. This gives additional information to the `error` to help users debug the underlying issue.
2. This prevents `error.bufferedData` from being empty when a single chunk was emitted and it was larger than `maxBuffer`. This can happen when `maxBuffer` is low, and when the stream `highWatermark` is high.
3. This ensures `error.bufferedData` is always exactly the same. For example, I was trying Execa with `get-stream@8` and the output of `childProcess.stdout` was inconsistent between test runs, since the underlying stream's chunks are timing-dependent. Therefore, the test was harder to reproduce consistently.