### PR TITLE
fix: set types property in package.json for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"types": "./source/index.d.ts",
 	"exports": {
 		"types": "./source/index.d.ts",
 		"default": "./source/index.js"


### PR DESCRIPTION
Hello! :wave:

Tried upgrading this package from v7.0.1 to 8.0.1, but using TypeScript, the types doesn't work anymore.

```sh
error TS2307: Cannot find module 'get-stream' or its corresponding type declarations.

import getStream from 'get-stream'
```

2 solutions exist to fix this issue:
1. Update `tsconfig.json` to use `"compilerOptions.moduleResolution": "NodeNext"`, ("NodeNext" instead of "ESNext")
2. Update this package to add the `types` property in `package.json`

The first solution doesn't work in every cases, not all project should have `"moduleResolution"` to use "NodeNext", while the second solution make it so that it works for everyone.

Thank you for this v8 release, there are amazing improvements. :tada: