### PR TITLE
Drop support for Node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 21
           - 20
           - 18
-          - 16
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"default": "./source/index.js"
 	},
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"benchmark": "node benchmarks/index.js",
@@ -43,11 +43,11 @@
 		"concat"
 	],
 	"devDependencies": {
-		"@types/node": "^20.5.0",
+		"@types/node": "^20.8.9",
 		"ava": "^5.3.1",
-		"precise-now": "^2.0.0",
+		"precise-now": "^3.0.0",
 		"stream-json": "^1.8.0",
-		"tsd": "^0.28.1",
+		"tsd": "^0.29.0",
 		"xo": "^0.56.0"
 	}
 }

--- a/test/array-buffer.js
+++ b/test/array-buffer.js
@@ -1,4 +1,4 @@
-import {Buffer, constants as BufferConstants, Blob} from 'node:buffer';
+import {Buffer, constants as BufferConstants} from 'node:buffer';
 import {arrayBuffer, blob} from 'node:stream/consumers';
 import test from 'ava';
 import {getStreamAsArrayBuffer, MaxBufferError} from '../source/index.js';


### PR DESCRIPTION
This drops support for Node 16, since it is not officially supported anymore.