### PR TITLE
Handle unusual error types

### DIFF
--- a/source/contents.js
+++ b/source/contents.js
@@ -16,8 +16,9 @@ export const getStreamContents = async (stream, {init, convertChunk, getSize, tr
 		appendFinalChunk({state, convertChunk, getSize, truncateChunk, addChunk, getFinalChunk, maxBuffer});
 		return finalize(state);
 	} catch (error) {
-		error.bufferedData = finalize(state);
-		throw error;
+		const normalizedError = typeof error === 'object' && error !== null ? error : new Error(error);
+		normalizedError.bufferedData = finalize(state);
+		throw normalizedError;
 	}
 };
 

--- a/test/contents.js
+++ b/test/contents.js
@@ -37,16 +37,21 @@ test('getStream should not affect additional listeners attached to the stream', 
 	t.is(await getStream(fixture), 'foobar');
 });
 
-const errorStream = async function * () {
+const errorStream = async function * (error) {
 	yield fixtureString;
 	await setTimeout(0);
-	throw new Error('test');
+	throw error;
 };
 
-test('set error.bufferedData when stream errors', async t => {
-	const {bufferedData} = await t.throwsAsync(setupString(errorStream));
+const testErrorStream = async (t, error) => {
+	const {bufferedData} = await t.throwsAsync(setupString(errorStream.bind(undefined, error)));
 	t.is(bufferedData, fixtureString);
-});
+};
+
+test('set error.bufferedData when stream errors', testErrorStream, new Error('test'));
+test('set error.bufferedData when stream error string', testErrorStream, 'test');
+test('set error.bufferedData when stream error null', testErrorStream, null);
+test('set error.bufferedData when stream error undefined', testErrorStream, undefined);
 
 const infiniteIteration = async function * () {
 	while (true) {


### PR DESCRIPTION
If the stream throws an error that is not an object, `get-stream` currently fails since it tries to assign `error.bufferedData` to it. This PR fixes this edge case.