### PR TITLE
Add a test for async iterables

### DIFF
--- a/test/contents.js
+++ b/test/contents.js
@@ -24,6 +24,24 @@ test('works with async iterable', async t => {
 	t.is(result, 'ab');
 });
 
+const finallyGenerator = async function * (state) {
+	try {
+		yield {};
+	} catch (error) {
+		state.error = true;
+		throw error;
+	} finally {
+		state.finally = true;
+	}
+};
+
+test('async iterable .return() is called on error, but not .throw()', async t => {
+	const state = {error: false, finally: false};
+	await t.throwsAsync(getStream(finallyGenerator(state)));
+	t.false(state.error);
+	t.true(state.finally);
+});
+
 test('get stream with mixed chunk types', async t => {
 	const fixtures = [fixtureString, fixtureBuffer, fixtureArrayBuffer, fixtureTypedArray, fixtureUint16Array, fixtureDataView];
 	const result = await setupString(fixtures);


### PR DESCRIPTION
This adds a new test to check that, when passing an async iterable and an error is thrown (e.g. due to `maxBuffer`), `iterator.throw()` is properly called. For a generator, this means `finally` blocks can be used to cleanup when `maxBuffer` is hit.