### PR TITLE
Remove `highWatermark` option

### DIFF
--- a/source/stream.js
+++ b/source/stream.js
@@ -23,10 +23,7 @@ const getStreamIterable = async function * (stream) {
 	handleStreamEnd(stream, controller, state);
 
 	try {
-		for await (const [chunk] of nodeImports.events.on(stream, 'data', {
-			signal: controller.signal,
-			highWatermark: stream.readableHighWaterMark,
-		})) {
+		for await (const [chunk] of nodeImports.events.on(stream, 'data', {signal: controller.signal})) {
 			yield chunk;
 		}
 	} catch (error) {

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,5 +1,4 @@
 import {once} from 'node:events';
-import {version} from 'node:process';
 import {Readable, Duplex} from 'node:stream';
 import {finished} from 'node:stream/promises';
 import {scheduler, setTimeout as pSetTimeout} from 'node:timers/promises';
@@ -267,30 +266,6 @@ const testMultipleReads = async (t, wait) => {
 
 test('Handles multiple successive fast reads', testMultipleReads, () => scheduler.yield());
 test('Handles multiple successive slow reads', testMultipleReads, () => pSetTimeout(100));
-
-// The `highWaterMark` option was added to `once()` by Node 20.
-// See https://github.com/nodejs/node/pull/41276
-const nodeMajor = version.split('.')[0].slice(1);
-if (nodeMajor >= 20) {
-	test('Pause stream when too much data at once', async t => {
-		const stream = new Readable({
-			read: onetime(function () {
-				this.push('.');
-				this.push('.');
-				this.push('.');
-				this.push('.');
-				this.push(null);
-			}),
-			highWaterMark: 2,
-		});
-		const [result] = await Promise.all([
-			getStream(stream),
-			once(stream, 'pause'),
-		]);
-		t.is(result, '....');
-		assertSuccess(t, stream, Readable);
-	});
-}
 
 test('Can call twice at the same time', async t => {
 	const stream = Readable.from(fixtureMultiString);


### PR DESCRIPTION
#121 added the `on(stream, 'data')`'s `highWatermark` option. However, I realized this does not make sense in this specific case.

That option is measured in number of `data` events, not in bytes. My PR assumed it was measured in bytes. Since we cannot know the average number of bytes per `data` event (i.e. per `readable.push()`), we cannot know the optimal value for this option.

Also, the point of `get-stream` is already to buffer all stream data. So this is not a big problem if `on(stream, 'data')` buffers it too: if some data is buffered by `on()`, it is not consumed yet. Once consumed, it will be buffered by `get-stream` instead. So using this option does not actually reduce memory consumption.

Finally, `get-stream`'s processing of each chunk is synchronous and fairly fast, so having a backlog of `data` events is unlikely.