### PR TITLE
Upgrade ReadableStream ponyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"concat"
 	],
 	"dependencies": {
-		"@sec-ant/readable-stream": "^0.4.1",
+		"@sec-ant/readable-stream": "^0.5.0",
 		"is-stream": "^4.0.1"
 	},
 	"devDependencies": {

--- a/source/stream.js
+++ b/source/stream.js
@@ -12,7 +12,7 @@ export const getAsyncIterable = stream => {
 
 	// `ReadableStream[Symbol.asyncIterator]` support is missing in multiple browsers, so we ponyfill it
 	if (toString.call(stream) === '[object ReadableStream]') {
-		return asyncIterator.call(stream);
+		return asyncIterator(stream);
 	}
 
 	throw new TypeError('The first argument must be a Readable, a ReadableStream, or an async iterable.');


### PR DESCRIPTION
This upgrade the ReadableStream ponyfill.

See https://github.com/Sec-ant/readable-stream/releases/tag/v0.5.0

CI currently failing due to https://github.com/actions/node-versions/pull/182